### PR TITLE
Call the prepare method

### DIFF
--- a/src/bref/src/LaravelHttpHandler.php
+++ b/src/bref/src/LaravelHttpHandler.php
@@ -51,7 +51,7 @@ class LaravelHttpHandler extends HttpHandler
             $event->getBody()
         );
 
-        $response = $this->kernel->handle($request);
+        $response = $this->kernel->handle($request)->prepare($request);
         $this->kernel->terminate($request, $response);
 
         return new HttpResponse($response->getContent(), $response->headers->all(), $response->getStatusCode());

--- a/src/bref/src/LaravelHttpHandler.php
+++ b/src/bref/src/LaravelHttpHandler.php
@@ -51,8 +51,9 @@ class LaravelHttpHandler extends HttpHandler
             $event->getBody()
         );
 
-        $response = $this->kernel->handle($request)->prepare($request);
+        $response = $this->kernel->handle($request);
         $this->kernel->terminate($request, $response);
+        $response->prepare($request);
 
         return new HttpResponse($response->getContent(), $response->headers->all(), $response->getStatusCode());
     }


### PR DESCRIPTION
Otherwise html responses may get incorrectly rendered as text due to the missing content-type header. Indeed, I have seen this issue. ;)