### PR TITLE
Fixed server key case and manually setting headers

### DIFF
--- a/src/swoole/src/LaravelRunner.php
+++ b/src/swoole/src/LaravelRunner.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request as LaravelRequest;
 use Swoole\Http\Request;
 use Swoole\Http\Response;
 use Swoole\Http\Server;
+use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\Runtime\RunnerInterface;
 
 /**
@@ -41,9 +42,10 @@ class LaravelRunner implements RunnerInterface
                 [],
                 $request->cookie ?? [],
                 $request->files ?? [],
-                $request->server ?? [],
+                array_change_key_case($request->server ?? [], CASE_UPPER),
                 $request->rawContent()
             );
+            $sfRequest->headers = new HeaderBag($request->header);
 
             $sfResponse = $app->handle($sfRequest);
             foreach ($sfResponse->headers->all() as $name => $value) {

--- a/src/swoole/src/SymfonyRunner.php
+++ b/src/swoole/src/SymfonyRunner.php
@@ -5,6 +5,7 @@ namespace Runtime\Swoole;
 use Swoole\Http\Request;
 use Swoole\Http\Response;
 use Swoole\Http\Server;
+use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Runtime\RunnerInterface;
@@ -41,9 +42,10 @@ class SymfonyRunner implements RunnerInterface
                 [],
                 $request->cookie ?? [],
                 $request->files ?? [],
-                $request->server ?? [],
+                array_change_key_case($request->server ?? [], CASE_UPPER),
                 $request->rawContent()
             );
+            $sfRequest->headers = new HeaderBag($request->header);
 
             $sfResponse = $app->handle($sfRequest);
             foreach ($sfResponse->headers->all() as $name => $value) {


### PR DESCRIPTION
This PR changes the key case of the `$server` array so matches can be made.
It also manually sets the `HeaderBag` because headers are not sent as `HTTP_*` keys on Swoole's Request `$server`.