### PR TITLE
Fix compatibility of Kernel as HttpCache instance

### DIFF
--- a/src/roadrunner-symfony-nyholm/composer.json
+++ b/src/roadrunner-symfony-nyholm/composer.json
@@ -10,8 +10,11 @@
         }
     ],
     "require": {
+        "php": ">=7.2.5",
         "nyholm/psr7": "^1.4",
         "spiral/roadrunner": "^2.0",
+        "symfony/dependency-injection": "^5.3 || ^6.0",
+        "symfony/http-kernel": "^5.3 || ^6.0",
         "symfony/psr-http-message-bridge": "^2.1",
         "symfony/runtime": "^5.3 || ^6.0"
     },

--- a/src/roadrunner-symfony-nyholm/src/Runner.php
+++ b/src/roadrunner-symfony-nyholm/src/Runner.php
@@ -32,6 +32,9 @@ class Runner implements RunnerInterface
      */
     private $sessionOptions;
 
+    /**
+     * @var HttpKernelInterface|KernelInterface $kernel
+     */
     public function __construct(HttpKernelInterface $kernel, ?HttpFoundationFactoryInterface $httpFoundationFactory = null, ?HttpMessageFactoryInterface $httpMessageFactory = null)
     {
         $this->kernel = $kernel;

--- a/src/roadrunner-symfony-nyholm/src/Runner.php
+++ b/src/roadrunner-symfony-nyholm/src/Runner.php
@@ -33,7 +33,7 @@ class Runner implements RunnerInterface
     private $sessionOptions;
 
     /**
-     * @var HttpKernelInterface|KernelInterface $kernel
+     * @param HttpKernelInterface|KernelInterface $kernel
      */
     public function __construct($kernel, ?HttpFoundationFactoryInterface $httpFoundationFactory = null, ?HttpMessageFactoryInterface $httpMessageFactory = null)
     {

--- a/src/roadrunner-symfony-nyholm/src/Runner.php
+++ b/src/roadrunner-symfony-nyholm/src/Runner.php
@@ -11,6 +11,8 @@ use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpKernel\HttpCache\HttpCache;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\TerminableInterface;
 use Symfony\Component\Runtime\RunnerInterface;
@@ -30,12 +32,20 @@ class Runner implements RunnerInterface
      */
     private $sessionOptions;
 
-    public function __construct(KernelInterface $kernel, ?HttpFoundationFactoryInterface $httpFoundationFactory = null, ?HttpMessageFactoryInterface $httpMessageFactory = null)
+    public function __construct(HttpKernelInterface $kernel, ?HttpFoundationFactoryInterface $httpFoundationFactory = null, ?HttpMessageFactoryInterface $httpMessageFactory = null)
     {
         $this->kernel = $kernel;
         $this->psrFactory = new Psr7\Factory\Psr17Factory();
         $this->httpFoundationFactory = $httpFoundationFactory ?? new HttpFoundationFactory();
         $this->httpMessageFactory = $httpMessageFactory ?? new PsrHttpFactory($this->psrFactory, $this->psrFactory, $this->psrFactory, $this->psrFactory);
+
+        if ($kernel instanceof HttpCache) {
+            $kernel = $kernel->getKernel();
+        }
+
+        if (!$kernel instanceof KernelInterface) {
+            throw new \InvalidArgumentException(sprintf('Expected argument of type "%s", "%s" given.', KernelInterface::class, get_class($kernel)));
+        }
 
         $kernel->boot();
         $container = $kernel->getContainer();

--- a/src/roadrunner-symfony-nyholm/src/Runner.php
+++ b/src/roadrunner-symfony-nyholm/src/Runner.php
@@ -35,7 +35,7 @@ class Runner implements RunnerInterface
     /**
      * @var HttpKernelInterface|KernelInterface $kernel
      */
-    public function __construct(HttpKernelInterface $kernel, ?HttpFoundationFactoryInterface $httpFoundationFactory = null, ?HttpMessageFactoryInterface $httpMessageFactory = null)
+    public function __construct($kernel, ?HttpFoundationFactoryInterface $httpFoundationFactory = null, ?HttpMessageFactoryInterface $httpMessageFactory = null)
     {
         $this->kernel = $kernel;
         $this->psrFactory = new Psr7\Factory\Psr17Factory();

--- a/src/roadrunner-symfony-nyholm/src/Runner.php
+++ b/src/roadrunner-symfony-nyholm/src/Runner.php
@@ -44,7 +44,7 @@ class Runner implements RunnerInterface
         }
 
         if (!$kernel instanceof KernelInterface) {
-            throw new \InvalidArgumentException(sprintf('Expected argument of type "%s", "%s" given.', KernelInterface::class, get_class($kernel)));
+            throw new \InvalidArgumentException(sprintf('Expected argument of type "%s" or "%s", "%s" given.', KernelInterface::class, HttpCache::class, get_class($kernel)));
         }
 
         $kernel->boot();

--- a/src/roadrunner-symfony-nyholm/src/Runtime.php
+++ b/src/roadrunner-symfony-nyholm/src/Runtime.php
@@ -2,7 +2,7 @@
 
 namespace Runtime\RoadRunnerSymfonyNyholm;
 
-use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Runtime\RunnerInterface;
 use Symfony\Component\Runtime\SymfonyRuntime;
 
@@ -15,7 +15,7 @@ class Runtime extends SymfonyRuntime
 {
     public function getRunner(?object $application): RunnerInterface
     {
-        if ($application instanceof KernelInterface) {
+        if ($application instanceof HttpKernelInterface) {
             return new Runner($application);
         }
 

--- a/src/roadrunner-symfony-nyholm/src/Runtime.php
+++ b/src/roadrunner-symfony-nyholm/src/Runtime.php
@@ -2,7 +2,8 @@
 
 namespace Runtime\RoadRunnerSymfonyNyholm;
 
-use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\HttpCache\HttpCache;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Runtime\RunnerInterface;
 use Symfony\Component\Runtime\SymfonyRuntime;
 
@@ -15,7 +16,9 @@ class Runtime extends SymfonyRuntime
 {
     public function getRunner(?object $application): RunnerInterface
     {
-        if ($application instanceof HttpKernelInterface) {
+        if ($application instanceof KernelInterface
+            || ($application instanceof HttpCache && $application->getKernel() instanceof KernelInterface)
+        ) {
             return new Runner($application);
         }
 

--- a/src/roadrunner-symfony-nyholm/tests/RuntimeTest.php
+++ b/src/roadrunner-symfony-nyholm/tests/RuntimeTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Runtime\RoadRunnerSymfonyNyholm;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\HttpCache\HttpCache;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner;
+
+/**
+ * @author Alexander Schranz <alexander@sulu.io>
+ */
+class RuntimeTest extends TestCase
+{
+    public function testGetRuntimeHttpKernel(): void
+    {
+        $kernel = $this->getMockBuilder(KernelInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $kernel->expects($this->once())
+            ->method('boot');
+
+        $container = $this->getMockBuilder(ContainerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $container->expects($this->once())
+            ->method('getParameter')
+            ->with('session.storage.options')
+            ->will($this->returnValue([]));
+
+        $kernel->expects($this->once())
+            ->method('getContainer')
+            ->will($this->returnValue($container));
+
+        $kernel->expects($this->once())
+            ->method('shutdown');
+
+        $runtime = new Runtime();
+        $runner = $runtime->getRunner($kernel);
+
+        $this->assertInstanceOf(Runner::class, $runner);
+    }
+
+    public function testGetRuntimeHttpCache(): void
+    {
+        $httpCache = $this->getMockBuilder(HttpCache::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $kernel = $this->getMockBuilder(KernelInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $httpCache->expects($this->atLeastOnce())
+            ->method('getKernel')
+            ->will($this->returnValue($kernel));
+
+        $kernel->expects($this->once())
+            ->method('boot');
+
+        $container = $this->getMockBuilder(ContainerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $container->expects($this->once())
+            ->method('getParameter')
+            ->with('session.storage.options')
+            ->will($this->returnValue([]));
+
+        $kernel->expects($this->once())
+            ->method('getContainer')
+            ->will($this->returnValue($container));
+
+        $kernel->expects($this->once())
+            ->method('shutdown');
+
+        $runtime = new Runtime();
+        $runner = $runtime->getRunner($httpCache);
+
+        $this->assertInstanceOf(Runner::class, $runner);
+    }
+
+    public function testGetRuntimeHttpKernelInterface(): void
+    {
+        $kernel = $this->getMockBuilder(HttpKernelInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $runtime = new Runtime();
+        $runner = $runtime->getRunner($kernel);
+
+        $this->assertInstanceOf(HttpKernelRunner::class, $runner);
+    }
+}


### PR DESCRIPTION
Accidentally introduced a break in: https://github.com/php-runtime/runtime/pull/47 that the `HttpCache` instance which example in Sulu is created in the Front Controller is not longer supported: https://github.com/chirimoya/sulu-skeleton-runtime/blob/30712fcfe63b14a20b636ff871e1ff02c9ec08d7/public/website.php#L23