### PR TITLE
[Bref] Fix console runner output

### DIFF
--- a/src/bref/src/ConsoleApplicationRunner.php
+++ b/src/bref/src/ConsoleApplicationRunner.php
@@ -37,8 +37,9 @@ class ConsoleApplicationRunner implements RunnerInterface
                 $output = new BufferedOutput();
                 $exitCode = $this->application->run($input, $output);
 
+                $content = $output->fetch();
                 // Echo the output so that it is written to CloudWatch logs
-                echo $output->fetch();
+                echo $content;
 
                 if ($exitCode > 0) {
                     throw new \Exception('The command exited with a non-zero status code: '.$exitCode);
@@ -46,7 +47,7 @@ class ConsoleApplicationRunner implements RunnerInterface
 
                 return [
                     'exitCode' => $exitCode, // will always be 0
-                    'output' => $output->fetch(),
+                    'output' => $content,
                 ];
             });
         }


### PR DESCRIPTION
Fixes the issue identified in https://github.com/php-runtime/runtime/issues/61#issuecomment-879264420 when Symfony Console output would be written only to CloudWatch but not to Lambda output. Closes #61.