### PR TITLE
Fixed Swoole response status code

### DIFF
--- a/src/swoole/src/LaravelRunner.php
+++ b/src/swoole/src/LaravelRunner.php
@@ -54,6 +54,8 @@ class LaravelRunner implements RunnerInterface
                 $response->header($name, $value);
             }
         }
+
+        $response->status($sfResponse->getStatusCode());
         $response->end($sfResponse->getContent());
     }
 }

--- a/src/swoole/src/SymfonyRunner.php
+++ b/src/swoole/src/SymfonyRunner.php
@@ -54,6 +54,8 @@ class SymfonyRunner implements RunnerInterface
                 $response->header($name, $value);
             }
         }
+
+        $response->status($sfResponse->getStatusCode());
         $response->end($sfResponse->getContent());
     }
 }

--- a/src/swoole/tests/Unit/LaravelRunnerTest.php
+++ b/src/swoole/tests/Unit/LaravelRunnerTest.php
@@ -34,6 +34,7 @@ class LaravelRunnerTest extends TestCase
     {
         $sfResponse = $this->createMock(\Symfony\Component\HttpFoundation\Response::class);
         $sfResponse->headers = new HeaderBag(['X-Test' => 'Swoole-Runtime']);
+        $sfResponse->expects(self::once())->method('getStatusCode')->willReturn(201);
         $sfResponse->expects(self::once())->method('getContent')->willReturn('Test');
 
         $application = $this->createMock(Kernel::class);
@@ -44,6 +45,7 @@ class LaravelRunnerTest extends TestCase
 
         $response = $this->createMock(Response::class);
         $response->expects(self::once())->method('header')->with('x-test', 'Swoole-Runtime');
+        $response->expects(self::once())->method('status')->with(201);
         $response->expects(self::once())->method('end')->with('Test');
 
         $factory = $this->createMock(ServerFactory::class);

--- a/src/swoole/tests/Unit/SymfonyRunnerTest.php
+++ b/src/swoole/tests/Unit/SymfonyRunnerTest.php
@@ -34,6 +34,7 @@ class SymfonyRunnerTest extends TestCase
     {
         $sfResponse = $this->createMock(\Symfony\Component\HttpFoundation\Response::class);
         $sfResponse->headers = new HeaderBag(['X-Test' => 'Swoole-Runtime']);
+        $sfResponse->expects(self::once())->method('getStatusCode')->willReturn(201);
         $sfResponse->expects(self::once())->method('getContent')->willReturn('Test');
 
         $application = $this->createMock(HttpKernelInterface::class);
@@ -44,6 +45,7 @@ class SymfonyRunnerTest extends TestCase
 
         $response = $this->createMock(Response::class);
         $response->expects(self::once())->method('header')->with('x-test', 'Swoole-Runtime');
+        $response->expects(self::once())->method('status')->with(201);
         $response->expects(self::once())->method('end')->with('Test');
 
         $factory = $this->createMock(ServerFactory::class);


### PR DESCRIPTION
I've noticed that all responses, regardless of whether they were **201**, **404**, **500**, were returned with the same status code **200**. This PR contains the fix for both runners: Laravel and Symfony.