### PR TITLE
Add bref-local-handler.php to invoke bref handlers locally

### DIFF
--- a/src/bref/bin/bref-local-handler.php
+++ b/src/bref/bin/bref-local-handler.php
@@ -1,0 +1,58 @@
+#!/usr/bin/env php
+<?php
+
+if ($argc < 2) {
+    error_log("bref-local-handler.php must be invoked with at least one argument: \n./vendor/bin/bref-local-handler.php ./bin/container.php:App\\Service\\MyService [data or file path]");
+    exit(1);
+}
+
+/*
+ * Set the correct runtime
+ */
+if (!isset($_SERVER['APP_RUNTIME'])) {
+    $_SERVER['APP_RUNTIME'] = \Runtime\Bref\Runtime::class;
+}
+
+$config = [
+    'bref_runner_type' => 'local'
+];
+
+/*
+ * Handle first argument and prepare "handler"
+ */
+$handler = $argv[1];
+if (!isset($_SERVER['_HANDLER'])) {
+    $_SERVER['_HANDLER'] = $handler;
+}
+
+if (false === $pos = strpos($handler, ':')) {
+    $file = $handler;
+} else {
+    $file = substr($handler, 0, $pos);
+}
+$_SERVER['SCRIPT_FILENAME'] = $file;
+
+/*
+ * Handle second argument which is that data or a file with the data
+ */
+if (isset($argv[2])) {
+    $json = $argv[2];
+    if (is_file($json)) {
+        $json = file_get_contents($data);
+    }
+    
+    try {
+        $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+    } catch (JsonException $e) {
+        throw new Exception('The JSON provided for the event data is invalid JSON.');
+    }
+    
+    $config['bref_local_runner_data'] = $data;
+}
+
+/*
+ * Dump all options to APP_RUNTIME_OPTIONS
+ */
+$_SERVER['APP_RUNTIME_OPTIONS'] = array_merge($config, $_SERVER['APP_RUNTIME_OPTIONS'] ?? []);
+
+include $file;

--- a/src/bref/bin/bref-local-handler.php
+++ b/src/bref/bin/bref-local-handler.php
@@ -14,7 +14,7 @@ if (!isset($_SERVER['APP_RUNTIME'])) {
 }
 
 $config = [
-    'bref_runner_type' => 'local'
+    'bref_runner_type' => 'local',
 ];
 
 /*
@@ -38,15 +38,15 @@ $_SERVER['SCRIPT_FILENAME'] = $file;
 if (isset($argv[2])) {
     $json = $argv[2];
     if (is_file($json)) {
-        $json = file_get_contents($data);
+        $json = file_get_contents($json);
     }
-    
+
     try {
         $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
     } catch (JsonException $e) {
         throw new Exception('The JSON provided for the event data is invalid JSON.');
     }
-    
+
     $config['bref_local_runner_data'] = $data;
 }
 

--- a/src/bref/composer.json
+++ b/src/bref/composer.json
@@ -32,5 +32,8 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "bin": [
+        "bin/bref-local-handler.php"
+    ]
 }

--- a/src/bref/src/LocalRunner.php
+++ b/src/bref/src/LocalRunner.php
@@ -4,8 +4,6 @@ namespace Runtime\Bref;
 
 use Bref\Context\Context;
 use Bref\Event\Handler;
-use Bref\Runtime\Invoker;
-use Bref\Runtime\LambdaRuntime;
 use Symfony\Component\Runtime\RunnerInterface;
 
 /**
@@ -26,8 +24,7 @@ class LocalRunner implements RunnerInterface
 
     public function run(): int
     {
-        $invoker = new Invoker();
-        $invoker->invoke($this->handler, $this->data, new Context('', 0, '', ''));
+        $this->handler->handle($this->data, new Context('', 0, '', ''));
 
         return 0;
     }

--- a/src/bref/src/LocalRunner.php
+++ b/src/bref/src/LocalRunner.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Runtime\Bref;
+
+use Bref\Context\Context;
+use Bref\Event\Handler;
+use Bref\Runtime\Invoker;
+use Bref\Runtime\LambdaRuntime;
+use Symfony\Component\Runtime\RunnerInterface;
+
+/**
+ * This will run BrefHandlers for local development.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class LocalRunner implements RunnerInterface
+{
+    private $handler;
+    private $data;
+
+    public function __construct(Handler $handler, $data)
+    {
+        $this->handler = $handler;
+        $this->data = $data;
+    }
+
+    public function run(): int
+    {
+        $invoker = new Invoker();
+        $invoker->invoke($this->handler, $this->data, new Context('', 0, '', ''));
+
+        return 0;
+    }
+}


### PR DESCRIPTION
This is a convent way for all non-HTTP handlers to be invoked locally. It is a replacement for `./vendor/bin/bref local`. `./vendor/bin/bref local` does not work with the runtime component. 

## How to use

To invoke the `App\Lambda\MyLambda` service
```
./vendor/bin/bref-local-handler.php ./bin/container.php:App\\Lambda\\MyLambda 
```


To invoke the `App\Lambda\MyLambda` service with some event data
```
./vendor/bin/bref-local-handler.php ./bin/container.php:App\\Lambda\\MyLambda '{"foo":"bar"}'
```


To invoke the `App\Lambda\MyLambda` service with some event data stored in a file
```
./vendor/bin/bref-local-handler.php ./bin/container.php:App\\Lambda\\MyLambda example/input.json
```

