### PR TITLE
Add Swoole's Server socket type

### DIFF
--- a/src/swoole/src/ServerFactory.php
+++ b/src/swoole/src/ServerFactory.php
@@ -15,6 +15,7 @@ class ServerFactory
         'host' => '127.0.0.1',
         'port' => 8000,
         'mode' => 2, // SWOOLE_PROCESS
+        'sock_type' => 1, // SWOOLE_SOCK_TCP
         'settings' => [],
     ];
 
@@ -31,13 +32,14 @@ class ServerFactory
         $options['host'] = $options['host'] ?? $_SERVER['SWOOLE_HOST'] ?? $_ENV['SWOOLE_HOST'] ?? self::DEFAULT_OPTIONS['host'];
         $options['port'] = $options['port'] ?? $_SERVER['SWOOLE_PORT'] ?? $_ENV['SWOOLE_PORT'] ?? self::DEFAULT_OPTIONS['port'];
         $options['mode'] = $options['mode'] ?? $_SERVER['SWOOLE_MODE'] ?? $_ENV['SWOOLE_MODE'] ?? self::DEFAULT_OPTIONS['mode'];
+        $options['sock_type'] = $options['sock_type'] ?? $_SERVER['SWOOLE_SOCK_TYPE'] ?? $_ENV['SWOOLE_SOCK_TYPE'] ?? self::DEFAULT_OPTIONS['sock_type'];
 
         $this->options = array_replace_recursive(self::DEFAULT_OPTIONS, $options);
     }
 
     public function createServer(callable $requestHandler): Server
     {
-        $server = new Server($this->options['host'], (int) $this->options['port'], (int) $this->options['mode']);
+        $server = new Server($this->options['host'], (int) $this->options['port'], (int) $this->options['mode'], (int) $this->options['sock_type']);
         $server->set($this->options['settings']);
         $server->on('request', $requestHandler);
 

--- a/src/swoole/tests/Unit/ServerFactoryTest.php
+++ b/src/swoole/tests/Unit/ServerFactoryTest.php
@@ -20,6 +20,7 @@ class ServerFactoryTest extends TestCase
         self::assertSame($defaults['host'], $server->host);
         self::assertSame($defaults['port'], $server->port);
         self::assertSame($defaults['mode'], $server->mode);
+        self::assertSame($defaults['sock_type'], $server->type);
         self::assertSame($defaults['settings'], $server->setting);
     }
 
@@ -29,6 +30,7 @@ class ServerFactoryTest extends TestCase
             'host' => '0.0.0.0',
             'port' => 9501,
             'mode' => 1,
+            'sock_type' => 2,
             'settings' => [
                 'worker_num' => 1,
             ],
@@ -41,6 +43,7 @@ class ServerFactoryTest extends TestCase
         self::assertSame('0.0.0.0', $server->host);
         self::assertSame(9501, $server->port);
         self::assertSame(1, $server->mode);
+        self::assertSame(2, $server->type);
         self::assertSame(['worker_num' => 1], $server->setting);
     }
 
@@ -48,6 +51,7 @@ class ServerFactoryTest extends TestCase
     {
         $options = [
             'mode' => 1,
+            'sock_type' => 2,
             'settings' => [
                 'worker_num' => 1,
             ],
@@ -61,6 +65,7 @@ class ServerFactoryTest extends TestCase
         self::assertSame($defaults['host'], $server->host);
         self::assertSame($defaults['port'], $server->port);
         self::assertSame(1, $server->mode);
+        self::assertSame(2, $server->type);
         self::assertSame(['worker_num' => 1], $server->setting);
     }
 }


### PR DESCRIPTION
This PR adds support of the missing 4th parameter in the Swoole's server constructor `$sock_type`. This parameter is extremely important when configuring SSL/TLS and when enabling the HTTP2 support.