### PR TITLE
[Bref] Add invocation and request context to the Request ServerBag

### DIFF
--- a/src/bref/composer.json
+++ b/src/bref/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "ext-json": "*",
         "bref/bref": "^1.2",
         "clue/arguments": "^2.1",
         "psr/http-server-handler": "^1.0",

--- a/src/bref/src/SymfonyRequestBridge.php
+++ b/src/bref/src/SymfonyRequestBridge.php
@@ -38,6 +38,8 @@ class SymfonyRequestBridge
             'REQUEST_TIME_FLOAT' => microtime(true),
             'REQUEST_URI' => $event->getUri(),
             'REMOTE_ADDR' => '127.0.0.1',
+            'LAMBDA_INVOCATION_CONTEXT' => json_encode($context),
+            'LAMBDA_REQUEST_CONTEXT' => json_encode($event->getRequestContext()),
         ], fn ($value) => null !== $value);
 
         foreach ($event->getHeaders() as $name => $values) {

--- a/src/bref/tests/SymfonyRequestBridgeTest.php
+++ b/src/bref/tests/SymfonyRequestBridgeTest.php
@@ -135,6 +135,19 @@ HTTP
         $this->assertSame('bar', $post['foo']);
     }
 
+    public function testLambdaContext()
+    {
+        $requestContext = ['http' => ['method' => 'GET']];
+        $request = SymfonyRequestBridge::convertRequest(new HttpRequestEvent([
+            'requestContext' => $requestContext,
+        ]), $invocationContext = $this->getContext());
+        $this->assertTrue($request->server->has('LAMBDA_INVOCATION_CONTEXT'));
+        $this->assertTrue($request->server->has('LAMBDA_REQUEST_CONTEXT'));
+
+        $this->assertSame(json_encode($invocationContext), $request->server->get('LAMBDA_INVOCATION_CONTEXT'));
+        $this->assertSame(json_encode($requestContext), $request->server->get('LAMBDA_REQUEST_CONTEXT'));
+    }
+
     private function getContext()
     {
         return new Context('id', 1000, 'function', 'trace');


### PR DESCRIPTION
As said in #77, currently we are loosing invocation and request context from AWS Lambda for the SymfonyHttpHandler.

Small PR to add it to the ServerBag of the Request object, to retrieve it in the code. 