### PR TITLE
[Bref] Signal to AWS if we fail to initialize the application

### DIFF
--- a/src/bref/src/Runtime.php
+++ b/src/bref/src/Runtime.php
@@ -48,9 +48,6 @@ class Runtime extends SymfonyRuntime
         }
     }
 
-    /**
-     * @param object|null $application
-     */
     private function tryToFindRunner(?object $application)
     {
         if ($application instanceof ContainerInterface) {


### PR DESCRIPTION
If we dont tell AWS this, they could keep trying to run our application even though it is broken. This will also make sure the output in Cloudwatch is a bit cleaner. 