### PR TITLE
[Swoole] Fix overwritten headers in the response

### DIFF
--- a/src/swoole/composer.json
+++ b/src/swoole/composer.json
@@ -12,6 +12,9 @@
     "require": {
         "symfony/runtime": "^5.3 || ^6.0"
     },
+    "conflict": {
+        "ext-swoole": "<4.6.0"
+    },
     "require-dev": {
         "illuminate/http": "^8.48",
         "swoole/ide-helper": "^4.6",

--- a/src/swoole/src/SymfonyHttpBridge.php
+++ b/src/swoole/src/SymfonyHttpBridge.php
@@ -38,9 +38,7 @@ final class SymfonyHttpBridge
     public static function reflectSymfonyResponse(SymfonyResponse $sfResponse, Response $response): void
     {
         foreach ($sfResponse->headers->all() as $name => $values) {
-            foreach ($values as $value) {
-                $response->header($name, $value);
-            }
+            $response->header($name, $values);
         }
 
         $response->status($sfResponse->getStatusCode());


### PR DESCRIPTION
This PR fixes overwritten headers in the Swoole response. 
I've encountered this issue while returning a response with some cookies. The `Set-Cookie` header is an example of a header that may appear several times, each for one cookie. 
The current implementation of the Swoole `Response::header()` replaces the header.
> "Repeating the same key more than once will just overwrite any previously set value before the response is sent back to the client." - Swoole docs

The fix uses a Swoole feature that is available since `v4.6.0`, it allows for passing arrays, objects, and so on. 