### PR TITLE
Fix a tiny grammar bug in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Since your application is not connected to the global state, it is very portable
 It is easy to create a `Runtime` to run the application with Bref, Swoole or
 ReactPHP without making any change to the application itself.
 
-Since most modern PHP application is based on Symfony's HttpKernel, PSR-7 or PSR-15
-we don't need too many different runtimes. This organization holds many PHP packages
-with runtimes for the most popular environments. It is not "*the source of all
-runtimes*", but rather a temporary place where runtimes can live before they move
-in to Bref/Swoole/RoadRunner etc.
+Since most modern PHP applications are based on Symfony's HttpKernel, PSR-7 or
+PSR-15 we don't need too many different runtimes. This organization holds many PHP
+packages with runtimes for the most popular environments. It is not "*the source of
+all runtimes*", but rather a temporary place where runtimes can live before they
+move in to Bref/Swoole/RoadRunner etc.
 
 All runtimes have hard dependencies to make installation easier. Everything should
 "just work".


### PR DESCRIPTION
- Change "Since most modern PHP application is based on..." to "Since most modern PHP applications are based on..."
- Reflow the paragraph to 84 characters, which seems to be the current way.