### PR TITLE
Fix #115 - buffer each `StreamedResponse` chunk when sending data to swoole worker output

### DIFF
--- a/src/swoole/phpunit.xml.dist
+++ b/src/swoole/phpunit.xml.dist
@@ -15,9 +15,9 @@
       <directory>./tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist processUncoveredFilesFromWhitelist="true">
+  <coverage>
+    <include>
       <directory suffix=".php">src</directory>
-    </whitelist>
-  </filter>
+    </include>
+  </coverage>
 </phpunit>

--- a/src/swoole/src/SymfonyHttpBridge.php
+++ b/src/swoole/src/SymfonyHttpBridge.php
@@ -50,7 +50,7 @@ final class SymfonyHttpBridge
                     $response->write($buffer);
 
                     return '';
-                });
+                }, 4096);
                 $sfResponse->sendContent();
                 ob_end_clean();
                 $response->end();

--- a/src/swoole/tests/Unit/RuntimeTest.php
+++ b/src/swoole/tests/Unit/RuntimeTest.php
@@ -15,7 +15,7 @@ class RuntimeTest extends TestCase
 {
     public function testGetRunnerCreatesARunnerForCallbacks(): void
     {
-        $options = [];
+        $options = ['error_handler' => false];
         $runtime = new Runtime($options);
 
         $application = static function (): void {
@@ -27,7 +27,7 @@ class RuntimeTest extends TestCase
 
     public function testGetRunnerCreatesARunnerForSymfony(): void
     {
-        $options = [];
+        $options = ['error_handler' => false];
         $runtime = new Runtime($options);
 
         $application = $this->createMock(HttpKernelInterface::class);
@@ -38,7 +38,7 @@ class RuntimeTest extends TestCase
 
     public function testGetRunnerCreatesARunnerForLaravel(): void
     {
-        $options = [];
+        $options = ['error_handler' => false];
         $runtime = new Runtime($options);
 
         $application = $this->createMock(Kernel::class);
@@ -49,7 +49,7 @@ class RuntimeTest extends TestCase
 
     public function testGetRunnerFallbacksToClosureRunner(): void
     {
-        $options = [];
+        $options = ['error_handler' => false];
         $runtime = new Runtime($options);
 
         $runner = $runtime->getRunner(null);

--- a/src/swoole/tests/Unit/SymfonyHttpBridgeTest.php
+++ b/src/swoole/tests/Unit/SymfonyHttpBridgeTest.php
@@ -129,4 +129,23 @@ class SymfonyHttpBridgeTest extends TestCase
 
         SymfonyHttpBridge::reflectSymfonyResponse($sfResponse, $response);
     }
+
+    public function testStreamedResponseWillRespondWithOneChunkAtATime(): void
+    {
+        $sfResponse = new StreamedResponse(static function () {
+            echo str_repeat('a', 4096);
+            echo str_repeat('b', 4095);
+        });
+
+        $response = $this->createMock(Response::class);
+        $response->expects(self::exactly(2))
+            ->method('write')
+            ->with(self::logicalOr(
+                str_repeat('a', 4096),
+                str_repeat('b', 4095)
+            ));
+        $response->expects(self::once())->method('end');
+
+        SymfonyHttpBridge::reflectSymfonyResponse($sfResponse, $response);
+    }
 }


### PR DESCRIPTION
This change ensures that, when converting a `StreamedResponse` to output within `php-runtime/swoole`,
the output is streamed chunk-by-chunk, instead of being buffered in its entirety, and then being
sent out to the swooler server all in one shot.

This should fix some obvious performance, latency and memory issues related to streaming common responses
assembled by PHP-side processes.

Note: you will still need to disable symfony's `StreamedResponseListener` when working with this package.

Fixes #115