### PR TITLE
[react] runtime improvements

### DIFF
--- a/src/reactphp/README.md
+++ b/src/reactphp/README.md
@@ -42,3 +42,10 @@ return function (array $context) {
     return new Application($context['APP_ENV'] ?? 'dev');
 };
 ```
+
+## Options
+
+| Option | Description                                                                                | Default     |
+| --- |--------------------------------------------------------------------------------------------|-------------|
+| `host` | The host where the server should bind to (precedes `REACT_HOST` environment variable)      | `127.0.0.1` |
+| `port` | The port where the server should be listening (precedes `REACT_PORT` environment variable) | `8080`      |

--- a/src/reactphp/composer.json
+++ b/src/reactphp/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "psr/http-server-handler": "^1.0",
-        "react/http": "^1.2",
+        "react/http": "^1.6",
         "symfony/runtime": "^5.3 || ^6.0"
     },
     "require-dev": {

--- a/src/reactphp/src/Runner.php
+++ b/src/reactphp/src/Runner.php
@@ -11,9 +11,9 @@ class Runner implements RunnerInterface
     private RequestHandlerInterface $application;
     private ServerFactory $serverFactory;
 
-    public function __construct(ServerFactory $factory, RequestHandlerInterface $application)
+    public function __construct(ServerFactory $serverFactory, RequestHandlerInterface $application)
     {
-        $this->serverFactory = $factory;
+        $this->serverFactory = $serverFactory;
         $this->application = $application;
     }
 

--- a/src/reactphp/src/Runner.php
+++ b/src/reactphp/src/Runner.php
@@ -10,19 +10,16 @@ class Runner implements RunnerInterface
 {
     private RequestHandlerInterface $application;
     private ServerFactory $serverFactory;
-    private LoopInterface $loop;
 
-    public function __construct(ServerFactory $factory, LoopInterface $loop, RequestHandlerInterface $application)
+    public function __construct(ServerFactory $factory, RequestHandlerInterface $application)
     {
         $this->serverFactory = $factory;
-        $this->loop = $loop;
         $this->application = $application;
     }
 
     public function run(): int
     {
-        $this->serverFactory->createServer($this->loop, $this->application);
-        $this->loop->run();
+        $this->serverFactory->createServer($this->application);
 
         return 0;
     }

--- a/src/reactphp/src/Runner.php
+++ b/src/reactphp/src/Runner.php
@@ -3,7 +3,6 @@
 namespace Runtime\React;
 
 use Psr\Http\Server\RequestHandlerInterface;
-use React\EventLoop\LoopInterface;
 use Symfony\Component\Runtime\RunnerInterface;
 
 class Runner implements RunnerInterface

--- a/src/reactphp/src/Runner.php
+++ b/src/reactphp/src/Runner.php
@@ -18,7 +18,8 @@ class Runner implements RunnerInterface
 
     public function run(): int
     {
-        $this->serverFactory->createServer($this->application);
+        $loop = $this->serverFactory->createServer($this->application);
+        $loop->run();
 
         return 0;
     }

--- a/src/reactphp/src/Runtime.php
+++ b/src/reactphp/src/Runtime.php
@@ -3,7 +3,6 @@
 namespace Runtime\React;
 
 use Psr\Http\Server\RequestHandlerInterface;
-use React\EventLoop\Loop;
 use Symfony\Component\Runtime\GenericRuntime;
 use Symfony\Component\Runtime\RunnerInterface;
 
@@ -28,9 +27,8 @@ class Runtime extends GenericRuntime
 
     public function getRunner(?object $application): RunnerInterface
     {
-        $factory = new ServerFactory($this->options);
         if ($application instanceof RequestHandlerInterface) {
-            return new Runner($factory, $application);
+            return new Runner(new ServerFactory($this->options), $application);
         }
 
         return parent::getRunner($application);

--- a/src/reactphp/src/Runtime.php
+++ b/src/reactphp/src/Runtime.php
@@ -3,6 +3,7 @@
 namespace Runtime\React;
 
 use Psr\Http\Server\RequestHandlerInterface;
+use React\EventLoop\Loop;
 use Symfony\Component\Runtime\GenericRuntime;
 use Symfony\Component\Runtime\RunnerInterface;
 
@@ -13,8 +14,6 @@ use Symfony\Component\Runtime\RunnerInterface;
  */
 class Runtime extends GenericRuntime
 {
-    private $host;
-    private $port;
     private const DEFAULT_OPTIONS = [
         'host' => '127.0.0.1',
         'port' => 8080,
@@ -29,8 +28,9 @@ class Runtime extends GenericRuntime
 
     public function getRunner(?object $application): RunnerInterface
     {
+        $factory = new ServerFactory($this->options);
         if ($application instanceof RequestHandlerInterface) {
-            return new Runner($application, $this->host, $this->port);
+            return new Runner($factory, Loop::get(), $application);
         }
 
         return parent::getRunner($application);

--- a/src/reactphp/src/Runtime.php
+++ b/src/reactphp/src/Runtime.php
@@ -13,18 +13,24 @@ use Symfony\Component\Runtime\RunnerInterface;
  */
 class Runtime extends GenericRuntime
 {
+    private $host;
     private $port;
+    private const DEFAULT_OPTIONS = [
+        'host' => '127.0.0.1',
+        'port' => 8080,
+    ];
 
     public function __construct(array $options)
     {
-        $this->port = $options['port'] ?? 8080;
+        $options['host'] = $options['host'] ?? $_SERVER['REACT_HOST'] ?? $_ENV['REACT_HOST'] ?? self::DEFAULT_OPTIONS['host'];
+        $options['port'] = $options['port'] ?? $_SERVER['REACT_PORT'] ?? $_ENV['REACT_PORT'] ?? self::DEFAULT_OPTIONS['port'];
         parent::__construct($options);
     }
 
     public function getRunner(?object $application): RunnerInterface
     {
         if ($application instanceof RequestHandlerInterface) {
-            return new Runner($application, $this->port);
+            return new Runner($application, $this->host, $this->port);
         }
 
         return parent::getRunner($application);

--- a/src/reactphp/src/Runtime.php
+++ b/src/reactphp/src/Runtime.php
@@ -13,18 +13,6 @@ use Symfony\Component\Runtime\RunnerInterface;
  */
 class Runtime extends GenericRuntime
 {
-    private const DEFAULT_OPTIONS = [
-        'host' => '127.0.0.1',
-        'port' => 8080,
-    ];
-
-    public function __construct(array $options)
-    {
-        $options['host'] = $options['host'] ?? $_SERVER['REACT_HOST'] ?? $_ENV['REACT_HOST'] ?? self::DEFAULT_OPTIONS['host'];
-        $options['port'] = $options['port'] ?? $_SERVER['REACT_PORT'] ?? $_ENV['REACT_PORT'] ?? self::DEFAULT_OPTIONS['port'];
-        parent::__construct($options);
-    }
-
     public function getRunner(?object $application): RunnerInterface
     {
         if ($application instanceof RequestHandlerInterface) {

--- a/src/reactphp/src/Runtime.php
+++ b/src/reactphp/src/Runtime.php
@@ -30,7 +30,7 @@ class Runtime extends GenericRuntime
     {
         $factory = new ServerFactory($this->options);
         if ($application instanceof RequestHandlerInterface) {
-            return new Runner($factory, Loop::get(), $application);
+            return new Runner($factory, $application);
         }
 
         return parent::getRunner($application);

--- a/src/reactphp/src/ServerFactory.php
+++ b/src/reactphp/src/ServerFactory.php
@@ -45,7 +45,6 @@ class ServerFactory
 
         $socket = new SocketServer(sprintf('%s:%s', $this->options['host'], $this->options['port']), [], $loop);
         $server->listen($socket);
-        $loop->run();
 
         return $loop;
     }

--- a/src/reactphp/src/ServerFactory.php
+++ b/src/reactphp/src/ServerFactory.php
@@ -5,6 +5,7 @@ namespace Runtime\React;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use React\EventLoop\Loop;
+use React\EventLoop\LoopInterface;
 use React\Http\HttpServer;
 use React\Socket\SocketServer;
 
@@ -29,7 +30,7 @@ class ServerFactory
         $this->options = array_replace_recursive(self::DEFAULT_OPTIONS, $options);
     }
 
-    public function createServer(RequestHandlerInterface $requestHandler): HttpServer
+    public function createServer(RequestHandlerInterface $requestHandler): LoopInterface
     {
         $loop = Loop::get();
         $server = new HttpServer($loop, function (ServerRequestInterface $request) use ($requestHandler) {
@@ -40,7 +41,7 @@ class ServerFactory
         $server->listen($socket);
         $loop->run();
 
-        return $server;
+        return $loop;
     }
 
     public function getOptions(): array

--- a/src/reactphp/src/ServerFactory.php
+++ b/src/reactphp/src/ServerFactory.php
@@ -4,7 +4,7 @@ namespace Runtime\React;
 
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use React\EventLoop\LoopInterface;
+use React\EventLoop\Loop;
 use React\Http\HttpServer;
 use React\Socket\SocketServer;
 
@@ -29,14 +29,16 @@ class ServerFactory
         $this->options = array_replace_recursive(self::DEFAULT_OPTIONS, $options);
     }
 
-    public function createServer(LoopInterface $loop, RequestHandlerInterface $requestHandler): HttpServer
+    public function createServer(RequestHandlerInterface $requestHandler): HttpServer
     {
+        $loop = Loop::get();
         $server = new HttpServer($loop, function (ServerRequestInterface $request) use ($requestHandler) {
             return $requestHandler->handle($request);
         });
 
         $socket = new SocketServer(sprintf('%s:%s', $this->options['host'], $this->options['port']), [], $loop);
         $server->listen($socket);
+        $loop->run();
 
         return $server;
     }

--- a/src/reactphp/src/ServerFactory.php
+++ b/src/reactphp/src/ServerFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Runtime\React;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use React\EventLoop\LoopInterface;
+use React\Http\HttpServer;
+use React\Socket\SocketServer;
+
+class ServerFactory
+{
+    private const DEFAULT_OPTIONS = [
+        'host' => '127.0.0.1',
+        'port' => 8080,
+    ];
+    private array $options;
+
+    public static function getDefaultOptions(): array
+    {
+        return self::DEFAULT_OPTIONS;
+    }
+
+    public function __construct(array $options = [])
+    {
+        $options['host'] = $options['host'] ?? $_SERVER['REACT_HOST'] ?? $_ENV['REACT_HOST'] ?? self::DEFAULT_OPTIONS['host'];
+        $options['port'] = $options['port'] ?? $_SERVER['REACT_PORT'] ?? $_ENV['REACT_PORT'] ?? self::DEFAULT_OPTIONS['port'];
+
+        $this->options = array_replace_recursive(self::DEFAULT_OPTIONS, $options);
+    }
+
+    public function createServer(LoopInterface $loop, RequestHandlerInterface $requestHandler): HttpServer
+    {
+        $server = new HttpServer($loop, function (ServerRequestInterface $request) use ($requestHandler) {
+            return $requestHandler->handle($request);
+        });
+
+        $socket = new SocketServer(sprintf('%s:%s', $this->options['host'], $this->options['port']), [], $loop);
+        $server->listen($socket);
+
+        return $server;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+}

--- a/src/reactphp/src/ServerFactory.php
+++ b/src/reactphp/src/ServerFactory.php
@@ -33,6 +33,12 @@ class ServerFactory
     public function createServer(RequestHandlerInterface $requestHandler): LoopInterface
     {
         $loop = Loop::get();
+        $loop->addSignal(SIGTERM, function (int $signal) {
+            exit(128 + $signal);
+        });
+        $loop->addSignal(SIGKILL, function (int $signal) {
+            exit(128 + $signal);
+        });
         $server = new HttpServer($loop, function (ServerRequestInterface $request) use ($requestHandler) {
             return $requestHandler->handle($request);
         });

--- a/src/reactphp/tests/RunnerTest.php
+++ b/src/reactphp/tests/RunnerTest.php
@@ -14,7 +14,7 @@ class RunnerTest extends TestCase
 {
     public function testRun(): void
     {
-        $handler = function(){};
+        $handler = function () {};
         $loop = $this->createMock(LoopInterface::class);
         Loop::set($loop);
         $server = new HttpServer($handler); //final, cannot be mocked

--- a/src/reactphp/tests/RunnerTest.php
+++ b/src/reactphp/tests/RunnerTest.php
@@ -4,6 +4,7 @@ namespace Runtime\React\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Server\RequestHandlerInterface;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Http\HttpServer;
 use Runtime\React\Runner;
@@ -16,14 +17,14 @@ class RunnerTest extends TestCase
     {
         $handler = function(){};
         $loop = $this->createMock(LoopInterface::class);
+        Loop::set($loop);
         $server = new HttpServer($handler); //final, cannot be mocked
         $factory = $this->createMock(ServerFactory::class);
         $application = $this->createMock(RequestHandlerInterface::class);
 
         $factory->expects(self::once())->method('createServer')->willReturn($server);
-        $loop->expects(self::once())->method('run');
 
-        $runner = new Runner($factory, $loop, $application);
+        $runner = new Runner($factory, $application);
 
         self::assertSame(0, $runner->run());
     }

--- a/src/reactphp/tests/RunnerTest.php
+++ b/src/reactphp/tests/RunnerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Runtime\React\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Server\RequestHandlerInterface;
+use React\EventLoop\LoopInterface;
+use React\Http\HttpServer;
+use Runtime\React\Runner;
+use Runtime\React\ServerFactory;
+use Evenement\EventEmitter;
+
+class RunnerTest extends TestCase
+{
+    public function testRun(): void
+    {
+        $handler = function(){};
+        $loop = $this->createMock(LoopInterface::class);
+        $server = new HttpServer($handler); //final, cannot be mocked
+        $factory = $this->createMock(ServerFactory::class);
+        $application = $this->createMock(RequestHandlerInterface::class);
+
+        $factory->expects(self::once())->method('createServer')->willReturn($server);
+        $loop->expects(self::once())->method('run');
+
+        $runner = new Runner($factory, $loop, $application);
+
+        self::assertSame(0, $runner->run());
+    }
+}

--- a/src/reactphp/tests/RunnerTest.php
+++ b/src/reactphp/tests/RunnerTest.php
@@ -9,7 +9,6 @@ use React\EventLoop\LoopInterface;
 use React\Http\HttpServer;
 use Runtime\React\Runner;
 use Runtime\React\ServerFactory;
-use Evenement\EventEmitter;
 
 class RunnerTest extends TestCase
 {

--- a/src/reactphp/tests/RunnerTest.php
+++ b/src/reactphp/tests/RunnerTest.php
@@ -21,7 +21,7 @@ class RunnerTest extends TestCase
         $factory = $this->createMock(ServerFactory::class);
         $application = $this->createMock(RequestHandlerInterface::class);
 
-        $factory->expects(self::once())->method('createServer')->willReturn($server);
+        $factory->expects(self::once())->method('createServer')->willReturn($loop);
 
         $runner = new Runner($factory, $application);
 

--- a/src/reactphp/tests/RuntimeTest.php
+++ b/src/reactphp/tests/RuntimeTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Runtime\React\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Server\RequestHandlerInterface;
+use Runtime\React\Runner;
+use Runtime\React\Runtime;
+
+class RuntimeTest extends TestCase
+{
+    public function testGetRunnerCreatesARunnerForRequestHandlers(): void
+    {
+        $options = [];
+        $runtime = new Runtime($options);
+
+        $application = $this->createMock(RequestHandlerInterface::class);
+        $runner = $runtime->getRunner($application);
+
+        self::assertInstanceOf(Runner::class, $runner);
+    }
+}

--- a/src/reactphp/tests/ServerFactoryTest.php
+++ b/src/reactphp/tests/ServerFactoryTest.php
@@ -18,7 +18,7 @@ class ServerFactoryTest extends TestCase
         parent::setUp();
         $this->handler = $this->createMock(RequestHandlerInterface::class);
         $this->loop = $this->createMock(LoopInterface::class);
-        $this->loop->expects($this->once())->method('run');
+        $this->loop->expects($this->never())->method('run');
         Loop::set($this->loop);
     }
 

--- a/src/reactphp/tests/ServerFactoryTest.php
+++ b/src/reactphp/tests/ServerFactoryTest.php
@@ -26,9 +26,9 @@ class ServerFactoryTest extends TestCase
     public function testCreateServerWithDefaultOptions(): void
     {
         $factory = new ServerFactory();
-        $server = $factory->createServer($this->handler);
+        $loop = $factory->createServer($this->handler);
 
-        self::assertInstanceOf(HttpServer::class, $server);
+        self::assertInstanceOf(LoopInterface::class, $loop);
         self::assertSame(ServerFactory::getDefaultOptions(), $factory->getOptions());
     }
 
@@ -39,7 +39,7 @@ class ServerFactoryTest extends TestCase
             'port' => '9999',
         ];
         $factory = new ServerFactory($options);
-        $server = $factory->createServer($this->handler);
+        $factory->createServer($this->handler);
 
         self::assertSame($options, $factory->getOptions());
     }

--- a/src/reactphp/tests/ServerFactoryTest.php
+++ b/src/reactphp/tests/ServerFactoryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Runtime\React\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Server\RequestHandlerInterface;
+use React\EventLoop\LoopInterface;
+use React\Http\HttpServer;
+use Runtime\React\ServerFactory;
+
+class ServerFactoryTest extends TestCase
+{
+    private RequestHandlerInterface $handler;
+    private LoopInterface $loop;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->handler = $this->createMock(RequestHandlerInterface::class);
+        $this->loop = $this->createMock(LoopInterface::class);
+    }
+
+    public function testCreateServerWithDefaultOptions(): void
+    {
+        $factory = new ServerFactory();
+        $server = $factory->createServer($this->loop, $this->handler);
+
+        self::assertInstanceOf(HttpServer::class, $server);
+        self::assertSame(ServerFactory::getDefaultOptions(), $factory->getOptions());
+    }
+
+    public function testCreateServerWithOptions(): void
+    {
+        $options = [
+            'host' => '0.0.0.0',
+            'port' => '9999',
+        ];
+        $factory = new ServerFactory($options);
+
+        self::assertSame($options, $factory->getOptions());
+    }
+}

--- a/src/reactphp/tests/ServerFactoryTest.php
+++ b/src/reactphp/tests/ServerFactoryTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Server\RequestHandlerInterface;
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
-use React\Http\HttpServer;
 use Runtime\React\ServerFactory;
 
 class ServerFactoryTest extends TestCase

--- a/src/reactphp/tests/ServerFactoryTest.php
+++ b/src/reactphp/tests/ServerFactoryTest.php
@@ -4,6 +4,7 @@ namespace Runtime\React\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Server\RequestHandlerInterface;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Http\HttpServer;
 use Runtime\React\ServerFactory;
@@ -18,12 +19,14 @@ class ServerFactoryTest extends TestCase
         parent::setUp();
         $this->handler = $this->createMock(RequestHandlerInterface::class);
         $this->loop = $this->createMock(LoopInterface::class);
+        $this->loop->expects($this->once())->method('run');
+        Loop::set($this->loop);
     }
 
     public function testCreateServerWithDefaultOptions(): void
     {
         $factory = new ServerFactory();
-        $server = $factory->createServer($this->loop, $this->handler);
+        $server = $factory->createServer($this->handler);
 
         self::assertInstanceOf(HttpServer::class, $server);
         self::assertSame(ServerFactory::getDefaultOptions(), $factory->getOptions());
@@ -36,6 +39,7 @@ class ServerFactoryTest extends TestCase
             'port' => '9999',
         ];
         $factory = new ServerFactory($options);
+        $server = $factory->createServer($this->handler);
 
         self::assertSame($options, $factory->getOptions());
     }


### PR DESCRIPTION
Improving react code, based loosely on the swoole runtime:
- allow setting react host via options, env/server vars
- refactor react http server creation into a factory
- more react tests
- bump minimum required react version to allow replacement of some deprecated classes
- handle and exit on container kill/stop signals (sigterm + sigkill)

The main objective is to allow listening on interfaces other than 127.0.0.1 (eg 0.0.0.0 for container-based installations)