### PR TITLE
[FrankenPHP] Relax php requirement - allow 8.0

### DIFF
--- a/src/frankenphp-symfony/composer.json
+++ b/src/frankenphp-symfony/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=8.2.0",
+        "php": ">=8.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "symfony/http-kernel": "^5.4 || ^6.0",
         "symfony/runtime": "^5.4 || ^6.0"


### PR DESCRIPTION
Allows playing with https://github.com/dunglas/frankenphp-demo with PHP 8.1 installed locally and without need to tweak the README instructions. Otherwise:

<img width="870" alt="Screenshot 2022-10-16 at 15 38 36" src="https://user-images.githubusercontent.com/7502063/196038621-8b2be14f-bc2b-46ab-8b9e-03be3ff304e2.png">

Let's revisit this only once php 8.2 stable gets released.