### PR TITLE
Change SIGKILL to SIGHUP

### DIFF
--- a/src/reactphp/src/ServerFactory.php
+++ b/src/reactphp/src/ServerFactory.php
@@ -36,7 +36,7 @@ class ServerFactory
         $loop->addSignal(SIGTERM, function (int $signal) {
             exit(128 + $signal);
         });
-        $loop->addSignal(SIGKILL, function (int $signal) {
+        $loop->addSignal(SIGHUP, function (int $signal) {
             exit(128 + $signal);
         });
         $server = new HttpServer($loop, function (ServerRequestInterface $request) use ($requestHandler) {

--- a/src/reactphp/src/ServerFactory.php
+++ b/src/reactphp/src/ServerFactory.php
@@ -36,9 +36,6 @@ class ServerFactory
         $loop->addSignal(SIGTERM, function (int $signal) {
             exit(128 + $signal);
         });
-        $loop->addSignal(SIGHUP, function (int $signal) {
-            exit(128 + $signal);
-        });
         $server = new HttpServer($loop, function (ServerRequestInterface $request) use ($requestHandler) {
             return $requestHandler->handle($request);
         });


### PR DESCRIPTION
Fix for:
> Fatal error: Error installing signal handler for 9 in /app/vendor/react/event-loop/src/StreamSelectLoop.php on line 161

From https://www.php.net/manual/en/function.pcntl-signal.php#83981 (14 years old):
>  You cannot assign a signal handler for SIGKILL (kill -9).