### PR TITLE
[Swoole] Prepare request uri with query string

### DIFF
--- a/src/swoole/src/SymfonyHttpBridge.php
+++ b/src/swoole/src/SymfonyHttpBridge.php
@@ -32,6 +32,8 @@ final class SymfonyHttpBridge
         );
         $sfRequest->headers = new HeaderBag($request->header ?? []);
 
+        self::prepareRequestUriWithQueryString($sfRequest);
+
         return $sfRequest;
     }
 
@@ -60,6 +62,22 @@ final class SymfonyHttpBridge
                 break;
             default:
                 $response->end($sfResponse->getContent());
+        }
+    }
+
+    /**
+     * REQUEST_URI returns the uri path only, should append with the query string if exists.
+     */
+    private static function prepareRequestUriWithQueryString(SymfonyRequest $sfRequest): void
+    {
+        if (!str_contains($sfRequest->server->get('REQUEST_URI', ''), '?')
+            && $sfRequest->server->has('QUERY_STRING')
+            && strlen($sfRequest->server->get('QUERY_STRING')) > 0
+        ) {
+            $sfRequest->server->set(
+                'REQUEST_URI',
+                $sfRequest->server->get('REQUEST_URI') .'?'. $sfRequest->server->get('QUERY_STRING')
+            );
         }
     }
 }

--- a/src/swoole/tests/Unit/SymfonyHttpBridgeTest.php
+++ b/src/swoole/tests/Unit/SymfonyHttpBridgeTest.php
@@ -148,4 +148,20 @@ class SymfonyHttpBridgeTest extends TestCase
 
         SymfonyHttpBridge::reflectSymfonyResponse($sfResponse, $response);
     }
+
+    public function testThatSwooleRequestedWithQuery(): void
+    {
+        $request = $this->createMock(Request::class);
+        $request->server = [
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => '/dummy',
+            'QUERY_STRING' => 'test=1'
+        ];
+
+        $sfRequest = SymfonyHttpBridge::convertSwooleRequest($request);
+
+        $this->assertSame('test=1', $sfRequest->server->get('QUERY_STRING'));
+        $this->assertSame('/dummy?test=1', $sfRequest->server->get('REQUEST_URI'));
+        $this->assertSame('/dummy?test=1', $sfRequest->getRequestUri());
+    }
 }


### PR DESCRIPTION
the REQUEST_URI will return the uri path only now. Should append with the query string if exists

