### PR TITLE
frankenphp-symfony: call gc_collect_cycles() after handling request

### DIFF
--- a/src/frankenphp-symfony/src/Runner.php
+++ b/src/frankenphp-symfony/src/Runner.php
@@ -16,11 +16,8 @@ use Symfony\Component\Runtime\RunnerInterface;
  */
 class Runner implements RunnerInterface
 {
-    private HttpKernelInterface $kernel;
-
-    public function __construct(HttpKernelInterface $kernel)
+    public function __construct(private HttpKernelInterface $kernel)
     {
-        $this->kernel = $kernel;
     }
 
     public function run(): int
@@ -40,6 +37,8 @@ class Runner implements RunnerInterface
             if ($this->kernel instanceof TerminableInterface && $sfRequest && $sfResponse) {
                 $this->kernel->terminate($sfRequest, $sfResponse);
             }
+
+            gc_collect_cycles();
         } while ($ret);
 
         return 0;


### PR DESCRIPTION
Triggering the garbage collector after the request has been handled and when the worker may be idle prevents the garbage collection from being randomly done in the middle of the handling of a request (which delays the delivery of the HTTP response).

Another option, that is done by Laravel Octone, is to trigger the GC when a configurable amount of memory has been consumed instead of after every request.
I think this patch is good enough for FrankenPHP as usually many workers will be available. 