### PR TITLE
Update psalm and composer normalize

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           php-version: 8.1
           coverage: none
-          tools: vimeo/psalm:5.0.0-beta1
+          tools: vimeo/psalm:5.15.0
 
       - name: Download dependencies
         uses: ramsey/composer-install@v2

--- a/composer.json
+++ b/composer.json
@@ -38,18 +38,18 @@
     "autoload": {
         "psr-4": {
             "Runtime\\Bref\\": "src/bref/src",
-            "Runtime\\Guzzle\\": "src/psr-guzzle/src",
             "Runtime\\GoogleCloud\\": "src/google-cloud/src",
+            "Runtime\\Guzzle\\": "src/psr-guzzle/src",
             "Runtime\\Laravel\\": "src/laravel/src",
             "Runtime\\Psr17\\": "src/psr-17/src",
             "Runtime\\PsrLaminas\\": "src/psr-laminas/src",
-            "Runtime\\PsrNyholm\\": "src/psr-nyholm/src",
             "Runtime\\PsrNyholmLaminas\\": "src/psr-nyholm-laminas/src",
+            "Runtime\\PsrNyholm\\": "src/psr-nyholm/src",
             "Runtime\\React\\": "src/react/src",
             "Runtime\\RoadRunnerNyholm\\": "src/roadrunner-nyholm/src",
             "Runtime\\RoadRunnerSymfonyNyholm\\": "src/roadrunner-symfony-nyholm/src",
-            "Runtime\\Swoole\\": "src/swoole/src",
-            "Runtime\\SwooleNyholm\\": "src/swoole-nyholm/src"
+            "Runtime\\SwooleNyholm\\": "src/swoole-nyholm/src",
+            "Runtime\\Swoole\\": "src/swoole/src"
         }
     },
     "autoload-dev": {

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,33 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.29.0@7ec5ffbd5f68ae03782d7fd33fff0c45a69f95b3">
+<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
+  <file src="src/bref/src/Runtime.php">
+    <InvalidArgument>
+      <code>$options</code>
+    </InvalidArgument>
+  </file>
   <file src="src/bref/src/SymfonyRequestBridge.php">
-    <InvalidArgument occurrences="1">
-      <code>$response-&gt;headers-&gt;all()</code>
+    <InvalidArgument>
+      <code><![CDATA[$response->headers->all()]]></code>
     </InvalidArgument>
   </file>
   <file src="src/frankenphp-symfony/src/Runner.php">
-    <UndefinedFunction occurrences="1"/>
+    <UndefinedFunction>
+      <code><![CDATA[\frankenphp_handle_request(function () use ($server, &$sfRequest, &$sfResponse): void {
+                // Merge the environment variables coming from DotEnv with the ones tight to the current request
+                $_SERVER += $server;
+
+                $sfRequest = Request::createFromGlobals();
+                $sfResponse = $this->kernel->handle($sfRequest);
+
+                $sfResponse->send();
+            })]]></code>
+    </UndefinedFunction>
   </file>
   <file src="src/google-cloud/router.php">
-    <MissingFile occurrences="1">
-      <code>require_once $_SERVER['SCRIPT_FILENAME'] = $defaultSource</code>
+    <MissingFile>
+      <code><![CDATA[require_once $_SERVER['SCRIPT_FILENAME'] = $defaultSource]]></code>
     </MissingFile>
   </file>
+  <file src="src/psr-17/src/Runtime.php">
+    <InvalidArgument>
+      <code>$options</code>
+    </InvalidArgument>
+  </file>
   <file src="src/psr-laminas/src/Runtime.php">
-    <InvalidArgument occurrences="2">
-      <code>['emitter' =&gt; $this-&gt;options['laminas_emitter'] ?? null]</code>
-      <code>['emitter' =&gt; $this-&gt;options['laminas_emitter'] ?? null]</code>
+    <InvalidArgument>
+      <code>$options</code>
     </InvalidArgument>
   </file>
   <file src="src/psr-nyholm-laminas/src/Runtime.php">
-    <InvalidArgument occurrences="2">
-      <code>['emitter' =&gt; $this-&gt;options['laminas_emitter'] ?? null]</code>
-      <code>['emitter' =&gt; $this-&gt;options['laminas_emitter'] ?? null]</code>
+    <InvalidArgument>
+      <code>$options</code>
     </InvalidArgument>
   </file>
   <file src="src/swoole/src/SymfonyHttpBridge.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>$sfResponse-&gt;getStatusCode()</code>
+    <InvalidScalarArgument>
+      <code><![CDATA[$sfResponse->getStatusCode()]]></code>
     </InvalidScalarArgument>
   </file>
 </files>

--- a/src/google-cloud/composer.json
+++ b/src/google-cloud/composer.json
@@ -21,15 +21,15 @@
     "prefer-stable": true,
     "autoload": {
         "psr-4": {
+            "Google\\CloudFunctions\\": "google/",
             "Runtime\\GoogleCloud\\": "src/",
-            "Symfony\\Runtime\\Google\\CloudFunctions\\": "runtime/",
-            "Google\\CloudFunctions\\": "google/"
+            "Symfony\\Runtime\\Google\\CloudFunctions\\": "runtime/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Runtime\\GoogleCloud\\Tests\\": "tests/runtime",
-            "Google\\CloudFunctions\\Tests\\": "tests/google/"
+            "Google\\CloudFunctions\\Tests\\": "tests/google/",
+            "Runtime\\GoogleCloud\\Tests\\": "tests/runtime"
         }
     },
     "bin": [


### PR DESCRIPTION
Currently composer normalize is erroring and psalm is erroring which blocks other pull requests. This will udpate the composer.json and add the parent::__construct($options); call to the baseline.