### PR TITLE
Revert "feat(road-runner): allow ^2023.1.0 and ^2.0"

### DIFF
--- a/src/roadrunner-symfony-nyholm/composer.json
+++ b/src/roadrunner-symfony-nyholm/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=8.0.5",
         "nyholm/psr7": "^1.4",
-        "spiral/roadrunner": "^2.0 || ^2023.1.0",
+        "spiral/roadrunner": "^2.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "symfony/http-kernel": "^5.4 || ^6.0",
         "symfony/psr-http-message-bridge": "^2.1",


### PR DESCRIPTION
Reverts php-runtime/runtime#138

This was accidently merged by auto merge. But the CI is failing and we should have a deeper look at why it is happening.