### PR TITLE
Updating links and examples to use Swoole instead of OpenSwoole

### DIFF
--- a/src/swoole-nyholm/README.md
+++ b/src/swoole-nyholm/README.md
@@ -1,6 +1,6 @@
 # Swoole Runtime  with nyholm/psr7
 
-A runtime for [Swoole](https://www.swoole.co.uk/).
+A runtime for [Swoole](https://www.swoole.com/).
 
 If you are new to the Symfony Runtime component, read more in the [main readme](https://github.com/php-runtime/runtime).
 
@@ -26,7 +26,7 @@ APP_RUNTIME=Runtime\SwooleNyholm\Runtime
 use Swoole\Http\Request;
 use Swoole\Http\Response;
 
-require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+require_once dirname(__DIR__) . '/vendor/autoload_runtime.php';
 
 return function () {
     return function (Request $request, Response $response) {
@@ -46,7 +46,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+require_once dirname(__DIR__) . '/vendor/autoload_runtime.php';
 
 class App implements RequestHandlerInterface {
     public function handle(ServerRequestInterface $request): ResponseInterface {
@@ -62,14 +62,14 @@ return function(): RequestHandlerInterface {
 
 ## Using Options
 
-You can define some configurations using Symfony's Runtime `APP_RUNTIME_OPTIONS` API.
+You can define some configurations using Symfony's Runtime [`APP_RUNTIME_OPTIONS` API](https://symfony.com/doc/current/components/runtime.html#using-options).
 
 | Option | Description | Default |
 | --- | --- | --- |
 | `host` | The host where the server should binds to (precedes `SWOOLE_HOST` environment variable) | `127.0.0.1` |
 | `port` | The port where the server should be listing (precedes `SWOOLE_PORT` environment variable) | `8000` |
 | `mode` | Swoole's server mode (precedes `SWOOLE_MODE` environment variable) | `SWOOLE_PROCESS` |
-| `settings` | All Swoole's server settings ([swoole.co.uk/docs/modules/swoole-server/configuration](https://www.swoole.co.uk/docs/modules/swoole-server/configuration)) | `[]` |
+| `settings` | All Swoole's server settings ([wiki.swoole.com/en/#/server/setting](https://wiki.swoole.com/en/#/server/setting) and [wiki.swoole.com/en/#/http_server?id=configuration-options](https://wiki.swoole.com/en/#/http_server?id=configuration-options)) | `[]` |
 
 ```php
 // public/index.php
@@ -81,13 +81,13 @@ $_SERVER['APP_RUNTIME_OPTIONS'] = [
     'port' => 9501,
     'mode' => SWOOLE_BASE,
     'settings' => [
-        \Swoole\Constant::OPTION_WORKER_NUM => swoole_cpu_num() * 2,
-        \Swoole\Constant::OPTION_ENABLE_STATIC_HANDLER => true,
-        \Swoole\Constant::OPTION_DOCUMENT_ROOT => dirname(__DIR__).'/public'
+        'worker_num' => swoole_cpu_num() * 2,
+        'enable_static_handler' => true,
+        'document_root' => dirname(__DIR__) . '/public'
     ],
 ];
 
-require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+require_once dirname(__DIR__) . '/vendor/autoload_runtime.php';
 
 return function (array $context) {
     return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);

--- a/src/swoole/README.md
+++ b/src/swoole/README.md
@@ -1,6 +1,6 @@
 # Swoole Runtime
 
-A runtime for [Swoole](https://www.swoole.co.uk/).
+A runtime for [Swoole](https://www.swoole.com/).
 
 If you are new to the Symfony Runtime component, read more in the [main readme](https://github.com/php-runtime/runtime).
 
@@ -26,7 +26,7 @@ APP_RUNTIME=Runtime\Swoole\Runtime
 use Swoole\Http\Request;
 use Swoole\Http\Response;
 
-require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+require_once dirname(__DIR__) . '/vendor/autoload_runtime.php';
 
 return function () {
     return function (Request $request, Response $response) {
@@ -43,7 +43,7 @@ return function () {
 
 use App\Kernel;
 
-require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+require_once dirname(__DIR__) . '/vendor/autoload_runtime.php';
 
 return function (array $context) {
     return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
@@ -52,14 +52,14 @@ return function (array $context) {
 
 ## Using Options
 
-You can define some configurations using Symfony's Runtime `APP_RUNTIME_OPTIONS` API.
+You can define some configurations using Symfony's Runtime [`APP_RUNTIME_OPTIONS` API](https://symfony.com/doc/current/components/runtime.html#using-options).
 
 | Option | Description | Default |
 | --- | --- | --- |
 | `host` | The host where the server should binds to (precedes `SWOOLE_HOST` environment variable) | `127.0.0.1` |
 | `port` | The port where the server should be listing (precedes `SWOOLE_PORT` environment variable) | `8000` |
 | `mode` | Swoole's server mode (precedes `SWOOLE_MODE` environment variable) | `SWOOLE_PROCESS` |
-| `settings` | All Swoole's server settings ([swoole.co.uk/docs/modules/swoole-server/configuration](https://www.swoole.co.uk/docs/modules/swoole-server/configuration)) | `[]` |
+| `settings` | All Swoole's server settings ([wiki.swoole.com/en/#/server/setting](https://wiki.swoole.com/en/#/server/setting) and [wiki.swoole.com/en/#/http_server?id=configuration-options](https://wiki.swoole.com/en/#/http_server?id=configuration-options)) | `[]` |
 
 ```php
 // public/index.php
@@ -71,13 +71,13 @@ $_SERVER['APP_RUNTIME_OPTIONS'] = [
     'port' => 9501,
     'mode' => SWOOLE_BASE,
     'settings' => [
-        \Swoole\Constant::OPTION_WORKER_NUM => swoole_cpu_num() * 2,
-        \Swoole\Constant::OPTION_ENABLE_STATIC_HANDLER => true,
-        \Swoole\Constant::OPTION_DOCUMENT_ROOT => dirname(__DIR__).'/public'
+        'worker_num' => swoole_cpu_num() * 2,
+        'enable_static_handler' => true,
+        'document_root' => dirname(__DIR__) . '/public'
     ],
 ];
 
-require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+require_once dirname(__DIR__) . '/vendor/autoload_runtime.php';
 
 return function (array $context) {
     return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);


### PR DESCRIPTION
https://swoole.co.uk/ redirects to OpenSwoole, which is a different extension than Swoole. This updates the README.md file with the correct examples for Swoole.