### PR TITLE
frankenphp: fix loop increment and break behavior

### DIFF
--- a/src/frankenphp-symfony/src/Runner.php
+++ b/src/frankenphp-symfony/src/Runner.php
@@ -49,7 +49,9 @@ class Runner implements RunnerInterface
             }
 
             gc_collect_cycles();
-        } while ($ret && (-1 === $this->loopMax || ++$loops <= $this->loopMax));
+
+            ++$loops;
+        } while ($ret && (-1 === $this->loopMax || $loops < $this->loopMax));
 
         return 0;
     }


### PR DESCRIPTION
The current Runtime doesn't behavior as documented.

```php
        } while ($ret && (-1 === $this->loopMax || ++$loops <= $this->loopMax));
```

Found two issues in my testing, hence this PR:
1. when `$ret` is true (which seems to be always the case?), the remaining conditions won't be evaluated, so `$loops` will never increment.
2. Setting `$loopMax` to 1 will result in 2 requests be handled before resetting. 

I'm not very sure of what `$ret` does (I thought this will return `false` when an unrecoverable error occurs, turns out it won't), but in anyway it dosen't sound right for the number of request not incrementing when the response is a successful one.