### PR TITLE
frankenphp: break loop when loopMax is reached

### DIFF
--- a/src/frankenphp-symfony/src/Runner.php
+++ b/src/frankenphp-symfony/src/Runner.php
@@ -49,7 +49,7 @@ class Runner implements RunnerInterface
             }
 
             gc_collect_cycles();
-        } while ($ret && (-1 === $this->loopMax || ++$loops <= $this->loopMax));
+        } while ($ret && (-1 === $this->loopMax || ++$loops < $this->loopMax));
 
         return 0;
     }


### PR DESCRIPTION
Fixes the issue that the loop doesn't exist when `$loopMax` is reached, but `$loopMax+1`. Please refer to https://github.com/php-runtime/runtime/pull/173 for details.