### PR TITLE
[Swoole] Map cookie header correctly when returning response.

### DIFF
--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -54,5 +54,31 @@
     <InvalidScalarArgument>
       <code><![CDATA[$sfResponse->getStatusCode()]]></code>
     </InvalidScalarArgument>
+    <TooManyArguments>
+      <code><![CDATA[$response->cookie]]></code>
+    </TooManyArguments>
+    <InvalidScalarArgument>
+      <code><![CDATA[$cookie->getExpiresTime()]]></code>
+    </InvalidScalarArgument>
+    <InvalidScalarArgument>
+      <code><![CDATA[$cookie->isHttpOnly()]]></code>
+    </InvalidScalarArgument>
+    <InvalidScalarArgument>
+      <code><![CDATA[$cookie->getSameSite()]]></code>
+    </InvalidScalarArgument>
+  </file>
+  <file src="src/swoole-nyholm/src/RequestHandlerRunner.php">
+    <TooManyArguments>
+      <code><![CDATA[$response->cookie]]></code>
+    </TooManyArguments>
+    <InvalidScalarArgument>
+      <code><![CDATA[$cookie->getExpiresTime()]]></code>
+    </InvalidScalarArgument>
+    <InvalidScalarArgument>
+      <code><![CDATA[$cookie->isHttpOnly()]]></code>
+    </InvalidScalarArgument>
+    <InvalidScalarArgument>
+      <code><![CDATA[$cookie->getSameSite()]]></code>
+    </InvalidScalarArgument>
   </file>
 </files>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="src/bref/src/Runtime.php">
     <InvalidArgument>
       <code><![CDATA[$options]]></code>
@@ -50,35 +50,25 @@
       <code><![CDATA[RoadRunner\Worker]]></code>
     </UndefinedClass>
   </file>
+  <file src="src/swoole-nyholm/src/RequestHandlerRunner.php">
+    <InvalidScalarArgument>
+      <code><![CDATA[$cookie->getExpiresTime()]]></code>
+      <code><![CDATA[$cookie->isHttpOnly()]]></code>
+      <code><![CDATA[$cookie->isSecure()]]></code>
+    </InvalidScalarArgument>
+    <TooManyArguments>
+      <code><![CDATA[cookie]]></code>
+    </TooManyArguments>
+  </file>
   <file src="src/swoole/src/SymfonyHttpBridge.php">
     <InvalidScalarArgument>
+      <code><![CDATA[$cookie->getExpiresTime()]]></code>
+      <code><![CDATA[$cookie->isHttpOnly()]]></code>
+      <code><![CDATA[$cookie->isSecure()]]></code>
       <code><![CDATA[$sfResponse->getStatusCode()]]></code>
     </InvalidScalarArgument>
     <TooManyArguments>
-      <code><![CDATA[$response->cookie]]></code>
+      <code><![CDATA[cookie]]></code>
     </TooManyArguments>
-    <InvalidScalarArgument>
-      <code><![CDATA[$cookie->getExpiresTime()]]></code>
-    </InvalidScalarArgument>
-    <InvalidScalarArgument>
-      <code><![CDATA[$cookie->isHttpOnly()]]></code>
-    </InvalidScalarArgument>
-    <InvalidScalarArgument>
-      <code><![CDATA[$cookie->getSameSite()]]></code>
-    </InvalidScalarArgument>
-  </file>
-  <file src="src/swoole-nyholm/src/RequestHandlerRunner.php">
-    <TooManyArguments>
-      <code><![CDATA[$response->cookie]]></code>
-    </TooManyArguments>
-    <InvalidScalarArgument>
-      <code><![CDATA[$cookie->getExpiresTime()]]></code>
-    </InvalidScalarArgument>
-    <InvalidScalarArgument>
-      <code><![CDATA[$cookie->isHttpOnly()]]></code>
-    </InvalidScalarArgument>
-    <InvalidScalarArgument>
-      <code><![CDATA[$cookie->getSameSite()]]></code>
-    </InvalidScalarArgument>
   </file>
 </files>

--- a/src/swoole-nyholm/src/RequestHandlerRunner.php
+++ b/src/swoole-nyholm/src/RequestHandlerRunner.php
@@ -73,7 +73,6 @@ class RequestHandlerRunner implements RunnerInterface
             }
         }
 
-
         $body = $psrResponse->getBody();
         $body->rewind();
 

--- a/src/swoole-nyholm/src/RequestHandlerRunner.php
+++ b/src/swoole-nyholm/src/RequestHandlerRunner.php
@@ -50,10 +50,23 @@ class RequestHandlerRunner implements RunnerInterface
 
         $response->setStatusCode($psrResponse->getStatusCode(), $psrResponse->getReasonPhrase());
 
-        foreach ($psrResponse->getHeaders() as $name => $values) {
+        foreach ($psrResponse->allPreserveCaseWithoutCookies() as $name => $values) {
             foreach ($values as $value) {
                 $response->setHeader($name, $value);
             }
+        }
+
+        foreach ($psrResponse->headers->getCookies() as $cookie) {
+            $response->cookie(
+                $cookie->getName(),
+                $cookie->getValue() ?? '',
+                $cookie->getExpiresTime(),
+                $cookie->getPath(),
+                $cookie->getDomain() ?? '',
+                $cookie->isSecure(),
+                $cookie->isHttpOnly(),
+                $cookie->getSameSite() ?? ''
+            );
         }
 
         $body = $psrResponse->getBody();

--- a/src/swoole-nyholm/tests/Unit/RequestHandlerRunnerTest.php
+++ b/src/swoole-nyholm/tests/Unit/RequestHandlerRunnerTest.php
@@ -31,6 +31,7 @@ class RequestHandlerRunnerTest extends TestCase
         $factory = $this->createMock(ServerFactory::class);
         $application = $this->createMock(RequestHandlerInterface::class);
         $psrResponse = $this->createMock(ResponseInterface::class);
+        $psrResponseInner = $this->createMock(ResponseInterface::class);
         $request = $this->createMock(Request::class);
         $response = $this->createMock(Response::class);
 
@@ -39,9 +40,10 @@ class RequestHandlerRunnerTest extends TestCase
 
         $application->expects(self::once())->method('handle')->willReturn($psrResponse);
 
-        $psrResponse->expects(self::once())->method('getHeaders')->willReturn([
+        $psrResponseInner->expects(self::once())->method('getHeaders')->willReturn([
             'X-Test' => ['Swoole-Runtime'],
         ]);
+        $psrResponse->expects(self::once())->method('withoutHeader')->willReturn($psrResponseInner);
         $psrResponse->expects(self::once())->method('getBody')->willReturn(Stream::create('Test'));
         $psrResponse->expects(self::once())->method('getStatusCode')->willReturn(200);
         $psrResponse->expects(self::once())->method('getReasonPhrase')->willReturn('OK');

--- a/src/swoole/src/SymfonyHttpBridge.php
+++ b/src/swoole/src/SymfonyHttpBridge.php
@@ -37,10 +37,23 @@ final class SymfonyHttpBridge
 
     public static function reflectSymfonyResponse(SymfonyResponse $sfResponse, Response $response): void
     {
-        foreach ($sfResponse->headers->all() as $name => $values) {
+        foreach ($sfResponse->headers->allPreserveCaseWithoutCookies() as $name => $values) {
             foreach ((array) $values as $value) {
                 $response->header((string) $name, $value);
             }
+        }
+
+        foreach ($sfResponse->headers->getCookies() as $cookie) {
+            $response->cookie(
+                $cookie->getName(),
+                $cookie->getValue() ?? '',
+                $cookie->getExpiresTime(),
+                $cookie->getPath(),
+                $cookie->getDomain() ?? '',
+                $cookie->isSecure(),
+                $cookie->isHttpOnly(),
+                $cookie->getSameSite() ?? ''
+            );
         }
 
         $response->status($sfResponse->getStatusCode());

--- a/src/swoole/tests/Unit/SymfonyHttpBridgeTest.php
+++ b/src/swoole/tests/Unit/SymfonyHttpBridgeTest.php
@@ -73,9 +73,9 @@ class SymfonyHttpBridgeTest extends TestCase
 
         $response = $this->createMock(Response::class);
         $expectedHeaders = [
-            ['x-test', 'Swoole-Runtime'],
-            ['set-cookie', $fooCookie],
-            ['set-cookie', $barCookie],
+            ['X-Test', 'Swoole-Runtime'],
+            ['Set-Cookie', $fooCookie],
+            ['Set-Cookie', $barCookie],
         ];
         $callCount = 0;
         $response->expects(self::exactly(3))->method('header')

--- a/src/swoole/tests/Unit/SymfonyHttpBridgeTest.php
+++ b/src/swoole/tests/Unit/SymfonyHttpBridgeTest.php
@@ -67,6 +67,8 @@ class SymfonyHttpBridgeTest extends TestCase
         $sfResponse->headers = new ResponseHeaderBag([
             'X-Test' => 'Swoole-Runtime',
             'Set-Cookie' => [$fooCookie, $barCookie],
+            'Cache-Control' => 'no-cache, private',
+            'Date' => 'Thu, 25 Dec 2025 19:20:06 GMT',
         ]);
         $sfResponse->expects(self::once())->method('getStatusCode')->willReturn(201);
         $sfResponse->expects(self::once())->method('getContent')->willReturn('Test');
@@ -74,9 +76,11 @@ class SymfonyHttpBridgeTest extends TestCase
         $response = $this->createMock(Response::class);
         $expectedHeaders = [
             ['X-Test', 'Swoole-Runtime'],
+            ['Cache-Control', 'no-cache, private'],
+            ['Date', 'Thu, 25 Dec 2025 19:20:06 GMT'],
         ];
         $callCount = 0;
-        $response->expects(self::exactly(1))->method('header')
+        $response->expects(self::exactly(3))->method('header')
             ->willReturnCallback(function ($key, $value) use ($expectedHeaders, &$callCount) {
                 $this->assertArrayHasKey($callCount, $expectedHeaders);
                 $this->assertEquals($expectedHeaders[$callCount][0], $key);
@@ -89,13 +93,13 @@ class SymfonyHttpBridgeTest extends TestCase
             ['foo', '123'],
             ['bar', '234'],
         ];
-        $callCount = 0;
+        $callCountCookie = 0;
         $response->expects(self::exactly(2))->method('cookie')
-            ->willReturnCallback(function ($name, $value) use ($expectedCookies, &$callCount) {
-                $this->assertArrayHasKey($callCount, $expectedCookies);
-                $this->assertEquals($expectedCookies[$callCount][0], $name);
-                $this->assertEquals($expectedCookies[$callCount][1], $value);
-                ++$callCount;
+            ->willReturnCallback(function ($name, $value) use ($expectedCookies, &$callCountCookie) {
+                $this->assertArrayHasKey($callCountCookie, $expectedCookies);
+                $this->assertEquals($expectedCookies[$callCountCookie][0], $name);
+                $this->assertEquals($expectedCookies[$callCountCookie][1], $value);
+                ++$callCountCookie;
 
                 return true;
             });

--- a/src/swoole/tests/Unit/SymfonyHttpBridgeTest.php
+++ b/src/swoole/tests/Unit/SymfonyHttpBridgeTest.php
@@ -9,9 +9,9 @@ use Swoole\Http\Response;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
@@ -64,7 +64,7 @@ class SymfonyHttpBridgeTest extends TestCase
         $barCookie = (string) new Cookie('bar', '234');
 
         $sfResponse = $this->createMock(SymfonyResponse::class);
-        $sfResponse->headers = new HeaderBag([
+        $sfResponse->headers = new ResponseHeaderBag([
             'X-Test' => 'Swoole-Runtime',
             'Set-Cookie' => [$fooCookie, $barCookie],
         ]);

--- a/src/swoole/tests/Unit/SymfonyHttpBridgeTest.php
+++ b/src/swoole/tests/Unit/SymfonyHttpBridgeTest.php
@@ -74,15 +74,27 @@ class SymfonyHttpBridgeTest extends TestCase
         $response = $this->createMock(Response::class);
         $expectedHeaders = [
             ['X-Test', 'Swoole-Runtime'],
-            ['Set-Cookie', $fooCookie],
-            ['Set-Cookie', $barCookie],
         ];
         $callCount = 0;
-        $response->expects(self::exactly(3))->method('header')
+        $response->expects(self::exactly(1))->method('header')
             ->willReturnCallback(function ($key, $value) use ($expectedHeaders, &$callCount) {
                 $this->assertArrayHasKey($callCount, $expectedHeaders);
                 $this->assertEquals($expectedHeaders[$callCount][0], $key);
                 $this->assertEquals($expectedHeaders[$callCount][1], $value);
+                ++$callCount;
+
+                return true;
+            });
+        $expectedCookies = [
+            ['foo', '123'],
+            ['bar', '234'],
+        ];
+        $callCount = 0;
+        $response->expects(self::exactly(2))->method('cookie')
+            ->willReturnCallback(function ($name, $value) use ($expectedCookies, &$callCount) {
+                $this->assertArrayHasKey($callCount, $expectedCookies);
+                $this->assertEquals($expectedCookies[$callCount][0], $name);
+                $this->assertEquals($expectedCookies[$callCount][1], $value);
                 ++$callCount;
 
                 return true;


### PR DESCRIPTION
Taken from: https://github.com/symfony-swoole/swoole-bundle/blob/1c18e2ba75d7671052d1ba07104747bebcbf6bab/src/Bridge/Symfony/HttpFoundation/ResponseHeadersAndStatusProcessor.php#L20

In current implementation, When multiple cookie values are expected to set, Only 1 cookie value will be appear in actual header (chrome's dev tool) while others are drop.

Relate to: https://github.com/php-runtime/runtime/issues/168
Ref: https://www.php.net/manual/en/class.swoole-http-response.php